### PR TITLE
Add missing dependency on `examples` module and add `configure` link

### DIFF
--- a/deprecated_libraries.info.yml
+++ b/deprecated_libraries.info.yml
@@ -3,7 +3,9 @@ description: Demonstrates use of Contrib replacements for deprecated Core Asset 
 type: module
 package: 'Example modules'
 core: 8.x
+configure: deprecated_libraries.info
 dependencies:
+  - examples
   - jquery_ui_accordion
   - jquery_ui_checkboxradio
   - jquery_ui_controlgroup


### PR DESCRIPTION
The module name and package hint at it, but the `dependencies` don't list the `examples` module as a dependency. It really _is_ a dependency though: `\Drupal\deprecated_libraries\Controller\DeprecatedLibsController` uses `Drupal\examples\Utility\DescriptionTemplateTrait`.